### PR TITLE
🔀 :: (#443) AcademicSchedule View Bug

### DIFF
--- a/Application/Sources/Scene/Schedule/AcademicSchedule/AcademicScheduleView.swift
+++ b/Application/Sources/Scene/Schedule/AcademicSchedule/AcademicScheduleView.swift
@@ -12,13 +12,13 @@ struct AcademicScheduleView: View {
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
             ScrollView(showsIndicators: false) {
+                SDCalendar(
+                    day: $viewModel.day,
+                    specialDate: viewModel.schedule.map { $0.date }
+                )
+                .padding(.top, 18)
+                .padding(.bottom, 20)
                 LazyVStack(spacing: 0) {
-                    SDCalendar(
-                        day: $viewModel.day,
-                        specialDate: viewModel.schedule.map { $0.date }
-                    )
-                    .padding(.top, 18)
-                    .padding(.bottom, 20)
                     ForEach(viewModel.schedule, id: \.id) {
                         if $0.date.toString(format: "yyyy MM") == viewModel.day.toString(format: "yyyy MM") {
                             AcademicScheduleCell(
@@ -31,6 +31,7 @@ struct AcademicScheduleView: View {
                         }
                     }
                 }
+                Spacer().frame(height: 100)
             }
             NavigationLink(destination: writeScheduleView) {
                 Image.pencilIcon


### PR DESCRIPTION
## 개요
> 학사 일정 뷰 버그 수정

## 작업사항
- 캘린더가 LazyVStack에 있어서 화면이 끊기는 현상 수정
- 일정 셀 아래 공백 추가

## UI
<img width="374" alt="스크린샷 2023-03-27 오후 1 16 07" src="https://user-images.githubusercontent.com/80248855/227839637-ea53c8b2-107e-4dd3-9694-006bfb6050ac.png">

![7fywt9](https://user-images.githubusercontent.com/80248855/227840174-7798f014-6758-451a-9411-828ef7cf7825.gif)

close #443

