### PR TITLE
🔀 :: (#490) fix notification bug

### DIFF
--- a/Modules/XDateUtil/Sources/DateFormat.swift
+++ b/Modules/XDateUtil/Sources/DateFormat.swift
@@ -1,8 +1,10 @@
 import Foundation
 
 public enum DateFormat: String {
+    /// yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS
+    case fullDateWithMilliSecondTime = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS"
     /// yyyy-MM-dd'T'HH:mm:ss
-    case fullDateWithTime = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS"
+    case fullDateWithTime = "yyyy-MM-dd'T'HH:mm:ss"
     /// yyyy-MM-dd
     case fullDate = "yyyy-MM-dd"
     /// yyyy

--- a/Modules/XDateUtil/Sources/StringToDate.swift
+++ b/Modules/XDateUtil/Sources/StringToDate.swift
@@ -4,6 +4,7 @@ public extension String {
     func toDate(format: DateFormat) -> Date {
         XDateFormatter.shared.dateFormat = format.rawValue
         guard let returnDate = XDateFormatter.shared.date(from: self) else {
+            print("toDate Error: Date로 format하려는 데이터의 형식이 DateFormat과 일치하지 않습니다.")
             return Date()
         }
         return returnDate

--- a/Services/AuthService/Sources/Data/Local/DataSource/LoaclTokenDataSourceImpl.swift
+++ b/Services/AuthService/Sources/Data/Local/DataSource/LoaclTokenDataSourceImpl.swift
@@ -32,7 +32,7 @@ class LoaclTokenDataSourceImpl: LoaclTokenDataSource {
     }
 
     func fetchExpiredDate() -> Date? {
-        self.keychain.get(.expiredAt)?.toDate(format: .fullDateWithTime)
+        self.keychain.get(.expiredAt)?.toDate(format: .fullDateWithMilliSecondTime)
     }
 
     func resetToken() {


### PR DESCRIPTION
## 개요
> 알림 리스트에서 모든 시간이 "방금전"으로 뜨는 버그 고침

## 작업사항
- toDate의 case 추가
- 밀리세컨드까지 포멧하는 toDate들 수정
- toDate로 포멧한 결과물이 nil일경우 뜨는 로그 추가

## 변경로직
- 서버에서 오는 date의 형식이 case와 다르면 nil이 떠버려 생기는 오류를 "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS"와 "yyyy-MM-dd'T'HH:mm:ss"의 케이스를 나누어 만들어 오류를 해결함

## UI

<img src="https://github.com/team-xquare/xquare-iOS/assets/80248855/6b5aeca5-0974-4fc5-aef8-a8ea6a6d4c8b" width="150px"></img>

close #490