### PR TITLE
🔀 :: (#519) notificationList bug fix

### DIFF
--- a/Application/Sources/Scene/Notification/Cell/NotificationListCell.swift
+++ b/Application/Sources/Scene/Notification/Cell/NotificationListCell.swift
@@ -36,7 +36,7 @@ struct NotificationListCell: View {
 
     private func getTimeForSend(date: Date) -> String {
             let today = Date()
-            var resultMinute = calculateToMinute(date: today) - calculateToMinute(date: date)
+            let resultMinute = calculateToMinute(date: today) - calculateToMinute(date: date)
             if resultMinute / 60 == 0 && resultMinute % 60 == 0 {
                 return "방금 전"
             } else if resultMinute / 60 == 0 {

--- a/Application/Sources/Scene/Notification/Cell/NotificationListCell.swift
+++ b/Application/Sources/Scene/Notification/Cell/NotificationListCell.swift
@@ -38,13 +38,13 @@ struct NotificationListCell: View {
         switch topic {
         case .applicationWeekendMeal, .applicationStay, .applicationMoveClassRoom, .applicationPicnic, .applicationPicnicPass, .applicationWeekendPicnic, .applicationWeekendPicnicReservation:
             return Image.application
-        case .allGoodPoint:
+        case .allGoodPoint, .feedBambooLike, .feedNoticeLike:
             return Image.thumbUpNotiIcon
         case .allBadPoint, .allPenaltyLevel:
             return Image.thumbDownNotiIcon
         case .scheduleLocal, .scheduleSocial:
             return Image.calendar
-        case .feedNotice, .feedBambooLike, .feedNoticeLike, .feedBambooComment, .feedNoticeComment:
+        case .feedNotice, .feedBambooComment, .feedNoticeComment:
             return Image.feed
         }
     }

--- a/Application/Sources/Scene/Notification/Cell/NotificationListCell.swift
+++ b/Application/Sources/Scene/Notification/Cell/NotificationListCell.swift
@@ -21,7 +21,7 @@ struct NotificationListCell: View {
                         .sdText(type: .caption2)
 
                     Spacer()
-                    Text(getTimeForSend(date: entity.sendAt))
+                    Text(entity.sendAt.getTimeAgoAsKoreanString())
                         .sdText(type: .caption2)
                 }
                 Text(entity.content)
@@ -33,26 +33,6 @@ struct NotificationListCell: View {
         .padding(16)
         .background(entity.isRead ? .white : .GrayScale.gray50)
     }
-
-    private func getTimeForSend(date: Date) -> String {
-            let today = Date()
-            let resultMinute = calculateToMinute(date: today) - calculateToMinute(date: date)
-            if resultMinute / 60 == 0 && resultMinute % 60 == 0 {
-                return "방금 전"
-            } else if resultMinute / 60 == 0 {
-                return "\(resultMinute % 60)분 전"
-            } else if resultMinute / 60 / 24 == 0 {
-                return "\(resultMinute / 60 % 24)시간 전"
-            } else if resultMinute / 60 / 24 / 30 == 0 {
-                return "\(resultMinute / 60 / 24 % 30)일 전"
-            } else {
-                return "\(resultMinute / 60 / 24 / 30)달 전"
-            }
-        }
-        private func calculateToMinute(date: Date) -> Int {
-            let dateList = date.toString(format: "MM:dd:HH:mm").split(separator: ":").map { Int($0)! }
-            return dateList[0] * 30 * 24 * 60 * 1 + dateList[1] * 24 * 60 * 1 + dateList[2] * 60 * 1 + dateList[3]
-        }
     // swiftlint:disable line_length
     private func topicToImage(topic: NotificationTopic) -> Image {
         switch topic {

--- a/Application/Sources/Scene/Notification/Cell/NotificationListCell.swift
+++ b/Application/Sources/Scene/Notification/Cell/NotificationListCell.swift
@@ -35,20 +35,24 @@ struct NotificationListCell: View {
     }
 
     private func getTimeForSend(date: Date) -> String {
-        let today = Date()
-
-        if Int(today.toString(format: "MM")) ?? 0 > Int(date.toString(format: "MM")) ?? 0 {
-            return "\((Int(today.toString(format: "MM")) ?? 0) - (Int(date.toString(format: "MM")) ?? 0))달 전"
-        } else if Int(today.toString(format: "dd")) ?? 0 > Int(date.toString(format: "dd")) ?? 0 {
-            return "\((Int(today.toString(format: "dd")) ?? 0) - (Int(date.toString(format: "dd")) ?? 0))일 전"
-        } else if Int(today.toString(format: "HH")) ?? 0 > Int(date.toString(format: "HH")) ?? 0 {
-            return "\((Int(today.toString(format: "HH")) ?? 0) - (Int(date.toString(format: "HH")) ?? 0))시간 전"
-        } else if Int(today.toString(format: "mm")) ?? 0 > Int(date.toString(format: "mm")) ?? 0 {
-            return "\((Int(today.toString(format: "mm")) ?? 0) - (Int(date.toString(format: "mm")) ?? 0))분 전"
-        } else {
-            return "방금 전"
+            let today = Date()
+            var resultMinute = calculateToMinute(date: today) - calculateToMinute(date: date)
+            if resultMinute / 60 == 0 && resultMinute % 60 == 0 {
+                return "방금 전"
+            } else if resultMinute / 60 == 0 {
+                return "\(resultMinute % 60)분 전"
+            } else if resultMinute / 60 / 24 == 0 {
+                return "\(resultMinute / 60 % 24)시간 전"
+            } else if resultMinute / 60 / 24 / 30 == 0 {
+                return "\(resultMinute / 60 / 24 % 30)일 전"
+            } else {
+                return "\(resultMinute / 60 / 24 / 30)달 전"
+            }
         }
-    }
+        private func calculateToMinute(date: Date) -> Int {
+            let dateList = date.toString(format: "MM:dd:HH:mm").split(separator: ":").map { Int($0)! }
+            return dateList[0] * 30 * 24 * 60 * 1 + dateList[1] * 24 * 60 * 1 + dateList[2] * 60 * 1 + dateList[3]
+        }
     // swiftlint:disable line_length
     private func topicToImage(topic: NotificationTopic) -> Image {
         switch topic {

--- a/Modules/XDateUtil/Sources/DateToString.swift
+++ b/Modules/XDateUtil/Sources/DateToString.swift
@@ -28,10 +28,10 @@ public extension Date {
             } else {
                 let yearDifference = (toDay.year! - sendAt.year!) * 12
                 for time in sendAt.month!..<toDay.month! + yearDifference {
-                    if time > 12 {
-                        resultMinute -= time - yearDifference.monthToDate(date: self)
+                    if time % 12 == 0 {
+                        resultMinute -= 12.monthToDate(date: self)
                     } else {
-                        resultMinute -= time.monthToDate(date: self)
+                        resultMinute -= time%12.monthToDate(date: self)
                     }
                 }
                 if resultMinute >= 1 {

--- a/Modules/XDateUtil/Sources/DateToString.swift
+++ b/Modules/XDateUtil/Sources/DateToString.swift
@@ -35,7 +35,11 @@ public extension Date {
                     }
                 }
                 if resultMinute >= 1 {
-                    return "\(toDay.month! + yearDifference - sendAt.month!)달 전"
+                    if toDay.month! + yearDifference - sendAt.month! >= 12 {
+                        return "\((toDay.month! + yearDifference - sendAt.month!) / 12)년 전"
+                    } else {
+                        return "\(toDay.month! + yearDifference - sendAt.month!)달 전"
+                    }
                 } else {
                     return "\(toDay.month! + yearDifference - sendAt.month! - 1)달 전"
                 }

--- a/Modules/XDateUtil/Sources/DateToString.swift
+++ b/Modules/XDateUtil/Sources/DateToString.swift
@@ -12,23 +12,34 @@ public extension Date {
     }
 
     func getTimeAgoAsKoreanString() -> String {
-        let today = Date()
-        let resultMinute = calculateToMinute(date: today) - calculateToMinute(date: self)
-        print("\(resultMinute) : \(today) - \(self)")
+        var resultMinute = Calendar.current.dateComponents([.minute], from: self, to: .now).minute!
         if resultMinute / 60 == 0 && resultMinute % 60 == 0 {
             return "방금 전"
         } else if resultMinute / 60 == 0 {
             return "\(resultMinute % 60)분 전"
         } else if resultMinute / 60 / 24 == 0 {
             return "\(resultMinute / 60 % 24)시간 전"
-        } else if resultMinute / 60 / 24 / 30 == 0 {
-            return "\(resultMinute / 60 / 24 % 30)일 전"
         } else {
-            return "\(resultMinute / 60 / 24 / 30)달 전"
+            resultMinute = resultMinute / 60 / 24
+            let toDay = Calendar.current.dateComponents([.year, .month, .day], from: .now)
+            let sendAt = Calendar.current.dateComponents([.year, .month, .day], from: self)
+            if (toDay.day! - sendAt.day! < 0 && toDay.month! == sendAt.month! + 1) || sendAt.month == toDay.month {
+                return "\(resultMinute)일 전"
+            } else {
+                let yearDifference = (toDay.year! - sendAt.year!) * 12
+                for time in sendAt.month!..<toDay.month! + yearDifference {
+                    if time > 12 {
+                        resultMinute -= time - yearDifference.monthToDate(date: self)
+                    } else {
+                        resultMinute -= time.monthToDate(date: self)
+                    }
+                }
+                if resultMinute >= 1 {
+                    return "\(toDay.month! + yearDifference - sendAt.month!)달 전"
+                } else {
+                    return "\(toDay.month! + yearDifference - sendAt.month! - 1)달 전"
+                }
+            }
         }
-    }
-    private func calculateToMinute(date: Date) -> Int {
-        let dateList = date.toString(format: "MM:dd:HH:mm").split(separator: ":").map { Int($0)! }
-        return dateList[0] * 30 * 24 * 60 * 1 + dateList[1] * 24 * 60 * 1 + dateList[2] * 60 * 1 + dateList[3]
     }
 }

--- a/Modules/XDateUtil/Sources/DateToString.swift
+++ b/Modules/XDateUtil/Sources/DateToString.swift
@@ -11,4 +11,24 @@ public extension Date {
         return XDateFormatter.shared.string(from: self)
     }
 
+    func getTimeAgoAsKoreanString() -> String {
+        let today = Date()
+        let resultMinute = calculateToMinute(date: today) - calculateToMinute(date: self)
+        print("\(resultMinute) : \(today) - \(self)")
+        if resultMinute / 60 == 0 && resultMinute % 60 == 0 {
+            return "방금 전"
+        } else if resultMinute / 60 == 0 {
+            return "\(resultMinute % 60)분 전"
+        } else if resultMinute / 60 / 24 == 0 {
+            return "\(resultMinute / 60 % 24)시간 전"
+        } else if resultMinute / 60 / 24 / 30 == 0 {
+            return "\(resultMinute / 60 / 24 % 30)일 전"
+        } else {
+            return "\(resultMinute / 60 / 24 / 30)달 전"
+        }
+    }
+    private func calculateToMinute(date: Date) -> Int {
+        let dateList = date.toString(format: "MM:dd:HH:mm").split(separator: ":").map { Int($0)! }
+        return dateList[0] * 30 * 24 * 60 * 1 + dateList[1] * 24 * 60 * 1 + dateList[2] * 60 * 1 + dateList[3]
+    }
 }

--- a/Modules/XDateUtil/Sources/monthToDay.swift
+++ b/Modules/XDateUtil/Sources/monthToDay.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension Int {
+    func monthToDate(date: Date) -> Int {
+        switch self {
+        case 1, 3, 5, 7, 8, 10, 12:
+            return 31
+        case 4, 6, 9, 11:
+            return 30
+        default:
+            if Calendar.current.dateComponents([.year], from: date).isLeapMonth! {
+                return 29
+            } else {
+                return 28
+            }
+        }
+    }
+}

--- a/Services/NotificationService/Sources/Data/Remote/Response/NotificationResponse.swift
+++ b/Services/NotificationService/Sources/Data/Remote/Response/NotificationResponse.swift
@@ -27,7 +27,7 @@ extension NotificationResponse {
             id: id,
             title: title,
             content: content,
-            sendAt: sendAt.toDate(format: .fullDateWithTime),
+            sendAt: sendAt.toDate(format: .fullDateWithMilliSecondTime),
             isRead: isRead,
             userId: userId,
             topic: .init(rawValue: topic) ?? .allGoodPoint


### PR DESCRIPTION
## 개요
> 알림 리스트에 방금 전이라고 뜨는 버그를 수정했어요

## 작업사항
- 알림 리스트 불러올때 dateFormat 타입을 .fullDateWithMilliSecondTime 으로 변경
- getTimeForSend() 로직 변경

## 변경로직
- getTimeForSend()을 (today -> 분으로 계산)  - (sentAt -> 분으로 계산) = 결과값을 60, 24, 30으로 나누며 시간 계산

## UI

https://github.com/team-xquare/xquare-iOS/assets/103028061/a631947d-c53a-4da3-b654-9a5c91be9d8a

