### PR TITLE
🔀 :: (#524) 개인 일정 공백버그 수정

### DIFF
--- a/Application/Sources/Scene/WriteSchedule/WriteScheduleViewModel.swift
+++ b/Application/Sources/Scene/WriteSchedule/WriteScheduleViewModel.swift
@@ -26,7 +26,13 @@ class WriteScheduleViewModel: ObservableObject {
             .disposed(by: disposeBag)
     }
     func checkStringDatasIsEmpty() {
-        self.postButtonIsDisabled = title.isEmpty || day.isEmpty
+        self.postButtonIsDisabled = isTitleCheck() || day.isEmpty
+    }
+    func isTitleCheck() -> Bool {
+        let strRegEx = "^(?! )[\\s\\S]{2,}$"
+        let pred = NSPredicate(format: "SELF MATCHES %@", strRegEx)
+
+        return !pred.evaluate(with: self.title)
     }
     func resetData() {
         self.title = ""


### PR DESCRIPTION
## 개요
> 개인 일정에 공백만 넣어도 생성되는 버그 수정

## 작업사항
- 정규식을 사용하여 조건을 설정함

## UI
https://github.com/team-xquare/xquare-iOS/assets/80248855/62d0d95b-b7b2-41f5-9cfa-6f4b880cfb82

close #524
