### PR TITLE
🔀 :: (#542) macOS에서 로그인시 iOS기기에 알림이 안오는 버그 수정

### DIFF
--- a/Application/Sources/Application/AppDelegate.swift
+++ b/Application/Sources/Application/AppDelegate.swift
@@ -38,7 +38,11 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         _ application: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
+        #if os(iOS)
         Messaging.messaging().apnsToken = deviceToken
+        #else
+        Messaging.messaging().apnsToken = nil
+        #endif
     }
 
     func userNotificationCenter(

--- a/Application/Sources/Scene/Login/LoginViewModel.swift
+++ b/Application/Sources/Scene/Login/LoginViewModel.swift
@@ -36,7 +36,7 @@ class LoginViewModel: ObservableObject {
             data: .init(
                 id: id,
                 password: password,
-                deviceToken: Messaging.messaging().fcmToken ?? ""
+                deviceToken: Messaging.messaging().fcmToken ?? "mac"
             ))
         .subscribe(onCompleted: { [weak self] in
             self?.isInternetNotWorking = false


### PR DESCRIPTION
## 개요
> macOS에서 로그인시 iOS기기에 알림이 안오는 버그 수정

## 작업사항
- os가 iOS일때만 디바이스토큰 넘기기
- 디바이스토큰이 nil일때 백엔드와 합의한 "mac"이라는 키워드 넘기기

## 변경로직
- 디바이스 토큰이 nil일때 "mac"을 넘김

close #542