### PR TITLE
🔀 :: (#579) 깃허브 랭킹 업데이트 로직 수정

### DIFF
--- a/Application/Sources/Scene/GitHubRanking/GithubRankingView.swift
+++ b/Application/Sources/Scene/GitHubRanking/GithubRankingView.swift
@@ -11,7 +11,11 @@ struct GithubRankingView: View {
     var body: some View {
         ScrollView(showsIndicators: false) {
             VStack(alignment: .leading, spacing: 16) {
-                TopRankView(topRankData: viewModel.githubRankList)
+                HStack {
+                    Spacer()
+                    TopRankView(topRankData: viewModel.githubRankList)
+                    Spacer()
+                }
                 Text("나의 순위")
                     .sdText(type: .body1, textColor: .GrayScale.gray900)
                 RankingListCellView(

--- a/Application/Sources/Scene/GitHubRanking/GithubRankingViewModel.swift
+++ b/Application/Sources/Scene/GitHubRanking/GithubRankingViewModel.swift
@@ -45,11 +45,7 @@ class GithubRankingViewModel: ObservableObject {
     }
 
     func updateGithubRanking() {
-        self.updateGithubRankingUseCase.execute()
-            .subscribe(onCompleted: {
-                self.fetchMyGithubInfo()
-                self.fetchGithubInfoList()
-            })
-            .disposed(by: disposeBag)
+        fetchMyGithubInfo()
+        fetchGithubInfoList()
     }
 }


### PR DESCRIPTION
## 개요
> 깃허브 랭킹 조회 업데이트 로직 수정

## 작업사항
- 랭킹 조회시 업데이트 하던 로직 -> 업데이트 하지 않고 바로 조회하는 로직으로 수정
- top3 랭킹 센터가 안맞는 문제 수정

## 변경로직
- 업데이트 후 조회 -> 바로 조회

## UI
<img src="<!-- 이미지 링크 작성 -->" width="150px"></img>
